### PR TITLE
Corrected mozroots call

### DIFF
--- a/Samples/ASPNET5.0_SampleForLinux/SetupDotNetOnLinux.sh
+++ b/Samples/ASPNET5.0_SampleForLinux/SetupDotNetOnLinux.sh
@@ -34,7 +34,7 @@ sudo certmgr -ssl -m https://nugetgallery.blob.core.windows.net
 sudo certmgr -ssl -m https://nuget.org
 sudo certmgr -ssl -m https://www.myget.org/F/aspnetvnext/
 
-mozroots --import –sync
+mozroots --import --sync
 
 wget http://dist.libuv.org/dist/v1.0.0-rc1/libuv-v1.0.0-rc1.tar.gz 
 tar -xvf libuv-v1.0.0-rc1.tar.gz


### PR DESCRIPTION
I think there is a mistake in the script. The parameters of mozroots are not correct in my opinion. It should be "--sync" instead of "-sync". It you run the script as it is, "kpm restore" will fail.
